### PR TITLE
Adds AppInviteDialog functionality

### DIFF
--- a/dependencies/android/src/org/haxe/extension/facebook/AppInviteDialogWrapper.java
+++ b/dependencies/android/src/org/haxe/extension/facebook/AppInviteDialogWrapper.java
@@ -1,0 +1,24 @@
+package org.haxe.extension.facebook;
+
+import java.lang.String;
+
+import com.facebook.share.model.AppInviteContent;
+import com.facebook.share.widget.AppInviteDialog;
+
+public class AppInviteDialogWrapper {
+
+	public static void appInviteDialog(String appLinkUrl, String previewImageUrl) {
+		
+		if (AppInviteDialog.canShow()) {
+
+			AppInviteContent content = new AppInviteContent.Builder()
+						.setApplinkUrl(appLinkUrl)
+						.setPreviewImageUrl(previewImageUrl)
+						.build();
+
+			AppInviteDialog.show(Facebook.instance.mainActivity, content);
+		}
+	}
+	
+
+}

--- a/extension/facebook/AppInviteDialog.hx
+++ b/extension/facebook/AppInviteDialog.hx
@@ -13,7 +13,7 @@ class AppInviteDialog {
 	/**
 	 * Open App Invite Dialog
 	 *
-	 * @param	appLinkUrl			App Link for what should be opened when the recipient clicks on the install/play button on the app invite page.
+	 * @param	appLinkUrl		App Link for what should be opened when the recipient clicks on the install/play button on the app invite page.
 	 * @param	previewImageUrl		URL to an image to be used in the invite.
 	 */
 	public function new(appLinkUrl : String, previewImageUrl : String = "")	{

--- a/extension/facebook/AppInviteDialog.hx
+++ b/extension/facebook/AppInviteDialog.hx
@@ -1,0 +1,28 @@
+package extension.facebook;
+
+#if (android && openfl)
+import openfl.utils.JNI;
+#end
+
+/**
+ * ...
+ * @author Paul Gene Thompson
+ */
+class AppInviteDialog {
+
+	/**
+	 * Open App Invite Dialog
+	 *
+	 * @param	appLinkUrl			App Link for what should be opened when the recipient clicks on the install/play button on the app invite page.
+	 * @param	previewImageUrl		URL to an image to be used in the invite.
+	 */
+	public function new(appLinkUrl : String, previewImageUrl : String = "")	{
+		#if android
+		jni_appInviteDialog(appLinkUrl, previewImageUrl);
+		#end
+	}
+
+	#if android
+	static var jni_appInviteDialog : Dynamic = JNI.createStaticMethod("org.haxe.extension.facebook.AppInviteDialogWrapper", "appInviteDialog", "(Ljava/lang/String;Ljava/lang/String;)V");
+	#end
+}


### PR DESCRIPTION
This adds https://developers.facebook.com/docs/app-invites/android

To use simply do:

new AppInviteDialog("https://www.mydomain.com/myapplink", "https://www.mydomain.com/my_invite_image.jpg");
